### PR TITLE
[Recovery] ubuntu-recovery-image fail with encryptfs

### DIFF
--- a/cmd/ubuntu-recovery-image/main.go
+++ b/cmd/ubuntu-recovery-image/main.go
@@ -60,7 +60,8 @@ func setupLoopDevice(recoveryOutputFile string, recoveryNR string, label string)
 	imageSize := MaxInt64(int64(recoverySize+20)*1024*1024, basefilest.Size())
 	err = syscall.Fallocate(int(outputfile.Fd()), 0, 0, imageSize)
 	if err != nil {
-		log.Printf("syscall.Fallocate may not support!! Try to use dd to allocate")
+		log.Print(err)
+		log.Print("syscall.Fallocate may not be supported!! Try to use dd to allocate")
 		rplib.DD("/dev/zero", recoveryOutputFile, "bs=1M", fmt.Sprintf("count=%d", imageSize/1024/1024), "conv=notrunc")
 		if _, err := os.Stat(recoveryOutputFile); os.IsNotExist(err) {
 			rplib.Checkerr(err)

--- a/cmd/ubuntu-recovery-image/main.go
+++ b/cmd/ubuntu-recovery-image/main.go
@@ -61,6 +61,12 @@ func setupLoopDevice(recoveryOutputFile string, recoveryNR string, label string)
 	err = syscall.Fallocate(int(outputfile.Fd()), 0, 0, imageSize)
 	if err != nil {
 		log.Print(err)
+	}
+	fileInfo, err := os.Stat(recoveryOutputFile)
+	if os.IsNotExist(err) {
+		rplib.Checkerr(err)
+	}
+	if fileInfo.Size() < imageSize {
 		log.Print("syscall.Fallocate may not be supported!! Try to use dd to allocate")
 		rplib.DD("/dev/zero", recoveryOutputFile, "bs=1M", fmt.Sprintf("count=%d", imageSize/1024/1024), "conv=notrunc")
 		if _, err := os.Stat(recoveryOutputFile); os.IsNotExist(err) {

--- a/cmd/ubuntu-recovery-image/main.go
+++ b/cmd/ubuntu-recovery-image/main.go
@@ -59,7 +59,13 @@ func setupLoopDevice(recoveryOutputFile string, recoveryNR string, label string)
 	// image size should be larger than or equal to base image. or the gpt table copy would failed
 	imageSize := MaxInt64(int64(recoverySize+20)*1024*1024, basefilest.Size())
 	err = syscall.Fallocate(int(outputfile.Fd()), 0, 0, imageSize)
-	rplib.Checkerr(err)
+	if err != nil {
+		log.Printf("syscall.Fallocate may not support!! Try to use dd to allocate")
+		rplib.DD("/dev/zero", recoveryOutputFile, "bs=1M", fmt.Sprintf("count=%d", imageSize/1024/1024), "conv=notrunc")
+		if _, err := os.Stat(recoveryOutputFile); os.IsNotExist(err) {
+			rplib.Checkerr(err)
+		}
+	}
 
 	//copy partition table
 	log.Printf("Copy partitition table")


### PR DESCRIPTION
It was being reported by Tony Espy in https://docs.google.com/document/d/1t_sXTCNElN_n5JzCOj3FOxlaRSLsGCXs1tl0ke5pVgw/edit :

"Please add a note which cautions that ubuntu-recovery-image may fail on certain filesystems as it uses the Go syscall.fallocate function.

In particular this fails on ecryptfs, so I needed to move my $GOPATH to /opt which is ext4, and properly supports fallocate.

As many people use encrypted $HOME by default, it would be good to add a warning about this.
"

We may consider to use another way to create file on certain system when it fails.