### PR TITLE
Fix parsing issue of initrd when there are microcodes included

### DIFF
--- a/cmd/ubuntu-recovery-image/main.go
+++ b/cmd/ubuntu-recovery-image/main.go
@@ -213,6 +213,8 @@ func setupInitrd(initrdImagePath string, tmpDir string) {
 	_ = rplib.Shellcmdoutput(extractInitrdCmd)
 
 	// overwrite initrd with initrd_local-include
+	// There will be two folders included. The main dir is the initrd target
+	initrdTmpDir = initrdTmpDir + "main"
 	rplib.Shellexec("rsync", "-r", "--exclude", ".gitkeep", "initrd_local-includes/", initrdTmpDir)
 
 	log.Printf("[recreate initrd]")

--- a/cmd/ubuntu-recovery-image/main.go
+++ b/cmd/ubuntu-recovery-image/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -208,40 +207,16 @@ func setupInitrd(initrdImagePath string, tmpDir string) {
 	defer syscall.Unmount(kernelsnapTmpDir, 0)
 
 	log.Printf("[unxz initrd in kernel snap]")
-	initrdImg := filepath.Join(kernelsnapTmpDir, "initrd.img")
-	content, err := ioutil.ReadFile(initrdImg)
-	rplib.Checkerr(err)
-	filetype := http.DetectContentType(content)
-	log.Println("filetype:", filetype)
-	var extractCmd string
-	switch filetype {
-	case "application/x-gzip":
-		extractCmd = "gunzip"
-	case "application/octet-stream":
-		extractCmd = "unxz"
-	default:
-		panic("Uknown file type")
-	}
-	// microcode workaround
-	//(cd $TMP2 ; cpio -id ; dd of=$NEW_INITRD) < $INITRD
-	//extractInitrdCmd := fmt.Sprintf("%s < %s/initrd.img | (cd %s; cpio -i )", extractCmd, kernelsnapTmpDir, initrdTmpDir)
-	separateInitrdCmd := fmt.Sprintf("(cd %s ; cpio -id; dd of=%s/new_initrd) < %s/initrd.img", tmpDir, tmpDir, kernelsnapTmpDir)
-	_ = rplib.Shellcmdoutput(separateInitrdCmd)
-	extractInitrdCmd := fmt.Sprintf("%s < %s/new_initrd | (cd %s; cpio -i )", extractCmd, tmpDir, initrdTmpDir)
+	extractCmd := "unmkinitramfs"
+	// microcode extract cmd
+	extractInitrdCmd := fmt.Sprintf("%s %s/initrd.img %s", extractCmd, kernelsnapTmpDir, initrdTmpDir)
 	_ = rplib.Shellcmdoutput(extractInitrdCmd)
 
 	// overwrite initrd with initrd_local-include
 	rplib.Shellexec("rsync", "-r", "--exclude", ".gitkeep", "initrd_local-includes/", initrdTmpDir)
 
 	log.Printf("[recreate initrd]")
-	switch filetype {
-	case "application/x-gzip":
-		_ = rplib.Shellcmdoutput(fmt.Sprintf("( cd %s; find | cpio --quiet -o -H newc ) | gzip -9 > %s", initrdTmpDir, initrdImagePath))
-	case "application/octet-stream":
-		_ = rplib.Shellcmdoutput(fmt.Sprintf("( cd %s; find | cpio --quiet -o -H newc ) | xz -c9 --check=crc32 > %s", initrdTmpDir, initrdImagePath))
-	default:
-		panic("Uknown file type")
-	}
+	_ = rplib.Shellcmdoutput(fmt.Sprintf("( cd %s; find | cpio --quiet -o -H newc ) | xz -c9 --check=crc32 > %s", initrdTmpDir, initrdImagePath))
 }
 
 func createRecoveryImage(recoveryNR string, recoveryOutputFile string, buildstamp utils.BuildStamp) {

--- a/cmd/ubuntu-recovery-image/main.go
+++ b/cmd/ubuntu-recovery-image/main.go
@@ -222,7 +222,12 @@ func setupInitrd(initrdImagePath string, tmpDir string) {
 	default:
 		panic("Uknown file type")
 	}
-	extractInitrdCmd := fmt.Sprintf("%s < %s/initrd.img | (cd %s; cpio -i )", extractCmd, kernelsnapTmpDir, initrdTmpDir)
+	// microcode workaround
+	//(cd $TMP2 ; cpio -id ; dd of=$NEW_INITRD) < $INITRD
+	//extractInitrdCmd := fmt.Sprintf("%s < %s/initrd.img | (cd %s; cpio -i )", extractCmd, kernelsnapTmpDir, initrdTmpDir)
+	separateInitrdCmd := fmt.Sprintf("(cd %s ; cpio -id; dd of=%s/new_initrd) < %s/initrd.img", tmpDir, tmpDir, kernelsnapTmpDir)
+	_ = rplib.Shellcmdoutput(separateInitrdCmd)
+	extractInitrdCmd := fmt.Sprintf("%s < %s/new_initrd | (cd %s; cpio -i )", extractCmd, tmpDir, initrdTmpDir)
 	_ = rplib.Shellcmdoutput(extractInitrdCmd)
 
 	// overwrite initrd with initrd_local-include


### PR DESCRIPTION
This issue have been resolved in the develop branch for a while and the resolution works well.
Now, in order to make builds using the [Lyoncore:20161109-0](https://github.com/Lyoncore/ubuntu-recovery-image/tree/20161109-0) branch run correctly, we have to backport the fix.